### PR TITLE
Remove Timestamp &t=1s from YouTube Video Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Join the [Discord community](https://discord.gg/eDZF75HG) to ask questions, shar
 
 ## How it works
 
-BetterBahn searches for train journeys and can use split ticketing to help you find cheaper options—though this is usually the exception, not the rule. For a detailed explanation and demonstration, check out the [YouTube video](https://www.youtube.com/watch?v=SxKtI8f5QTU&t=1s).
+BetterBahn searches for train journeys and can use split ticketing to help you find cheaper options—though this is usually the exception, not the rule. For a detailed explanation and demonstration, check out the [YouTube video](https://www.youtube.com/watch?v=SxKtI8f5QTU).
 
 ## About the Author
 


### PR DESCRIPTION
Removed the &t=1s Timestamp from the YouTube Video Link.
When &t=1s is included, the video starts at one second instead of at the very beginning