### PR TITLE
Set HOSTNAME environment variable in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -100,4 +100,5 @@ COPY --from=builder --chown=node:node /app/node_modules/db-hafas-stations ./node
 USER node
 
 EXPOSE 3000
+ENV HOSTNAME=0.0.0.0
 CMD ["node", "server.js"]


### PR DESCRIPTION
I've had issues with the Docker container not being available since node did bind to the default docker hostname.

```
 - Local:        http://47b2f88810f2:3000
 - Network:      http://47b2f88810f2:3000
```

If the HOSTNAME environment variable is set, it will be prioritized in the server.js file. This means that we can use this to bind to all interfaces ("0.0.0.0") instead.

```
- Local:        http://localhost:3000
- Network:      http://0.0.0.0:3000
```

And finally: Thanks you for this project! I highly appreciate the effort and your great idea!