### PR TITLE
fix(healthcheck): probe container IP instead of localhost (#100)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ USER node
 
 # Expose port and add healthcheck
 EXPOSE 3000
-HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 CMD curl -f http://localhost:3000 || exit 1
+HEALTHCHECK --interval=30s --timeout=10s --start-period=20s --retries=5 \
+    CMD IP=$(hostname -i | awk '{print $1}'); curl -fsS -4 "http://$IP:${PORT:-3000}" || exit 1
 
 CMD ["node", "server.js"]


### PR DESCRIPTION
The app binds to the container interface (e.g. 172.x.x.x) rather than 127.0.0.1. Healthcheck against localhost fails inside the container.

Change: probe container IP via `hostname -i`, force IPv4 (-4), and increase start_period/retries to avoid startup flakiness (Next.js needs enough time).

Note on docker-compose:
The repository’s compose file references `image: ghcr.io/l2xu/betterbahn:latest`.
This PR only changes the Dockerfile, so the fix takes effect **after** a new image
is built and published. Until then, compose runs that pull the prebuilt image
will still use the old healthcheck.

Closes #100.