### PR TITLE
fix: use localhost in healthcheck instead of container IP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,6 @@ USER node
 # Expose port and add healthcheck
 EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=10s --start-period=20s --retries=5 \
-    CMD IP=$(hostname -i | awk '{print $1}'); curl -fsS -4 "http://$IP:${PORT:-3000}" || exit 1
+    CMD curl -fsS http://localhost:${PORT:-3000} || exit 1
 
 CMD ["node", "server.js"]


### PR DESCRIPTION
Fixes #100

## Problem
The healthcheck in the Dockerfile was failing because it was trying to use the container's IP address obtained from `hostname -i`, but the Next.js app is listening on localhost.

## Solution
Changed the healthcheck command to use `localhost` directly instead of trying to determine the container's IP address. This is simpler, more reliable, and works correctly with Next.js standalone mode.

## Changes
- Updated Dockerfile healthcheck to use `localhost` instead of `hostname -i`
- Removed unnecessary IP address detection logic
- Simplified the curl command

## Testing
The healthcheck should now work correctly when the container is running, as it will check the app on localhost where Next.js is actually listening.