### PR TITLE
feat(search-history): implement search history functionality (Closes #201)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,8 @@ dist/
 
 # TypeScript
 /tsconfig.tsbuildinfo
+
+# Different package managers
+bun.lock
+package-lock.json
+yarn.lock

--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,3 @@ dist/
 
 # TypeScript
 /tsconfig.tsbuildinfo
-
-# Different package managers
-bun.lock
-package-lock.json
-yarn.lock

--- a/app/discount/DiscountContent.tsx
+++ b/app/discount/DiscountContent.tsx
@@ -24,25 +24,30 @@ export const DiscountContent = () => {
 	);
 
 	useEffect(() => {
-		if (journeysQuery.isSuccess && journeysQuery.data.length > 0) {
-			const journey = journeysQuery.data[0];
-			const firstLeg = journey.legs.at(0);
-			const lastLeg = journey.legs.at(-1);
+		if (!journeysQuery.isSuccess) return;
 
-			if (firstLeg?.origin?.name && lastLeg?.destination?.name) {
-				addToHistory({
-					vbid: params.vbid,
-					origin: firstLeg.origin.name,
-					destination: lastLeg.destination.name,
-					departureDate: firstLeg.departure.toISOString(),
-					price: journey.price?.amount ?? null,
-					travelClass: params.travelClass,
-					passengerAge: params.passengerAge,
-					bahnCard: params.bahnCard,
-					hasDeutschlandTicket: params.hasDeutschlandTicket,
-				});
-			}
-		}
+		const journey = journeysQuery.data[0];
+		if (!journey) return;
+
+		const firstLeg = journey.legs.at(0);
+		const lastLeg = journey.legs.at(-1);
+
+		const origin = firstLeg?.origin?.name;
+		const destination = lastLeg?.destination?.name;
+
+		if (!origin || !destination) return;
+
+		addToHistory({
+			vbid: params.vbid,
+			origin,
+			destination,
+			departureDate: firstLeg.departure.toISOString(),
+			price: journey.price?.amount ?? null,
+			travelClass: params.travelClass,
+			passengerAge: params.passengerAge,
+			bahnCard: params.bahnCard,
+			hasDeutschlandTicket: params.hasDeutschlandTicket,
+		});
 	}, [
 		journeysQuery.isSuccess,
 		journeysQuery.data,

--- a/app/discount/DiscountContent.tsx
+++ b/app/discount/DiscountContent.tsx
@@ -1,15 +1,17 @@
 import { ErrorDisplay } from "@/components/discount/ErrorDisplay";
 import { StatusBox, type Progress } from "@/components/discount/StatusBox";
 import { Journey } from "@/components/Journey";
+import { useSearchHistory } from "@/components/SearchForm/useSearchHistory";
 import type { VendoJourney } from "@/utils/schemas";
 import { trpc } from "@/utils/TRPCProvider";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { ComparisonView } from "./Analysis";
 import { useUrlParams } from "./useUrlParams";
 
 export const DiscountContent = () => {
 	const params = useUrlParams();
 	const journeysQuery = trpc.getJourney.useQuery(params);
+	const { addToHistory } = useSearchHistory();
 
 	const [analysisProgress, setAnalysisProgress] = useState<Progress | null>(
 		null
@@ -20,6 +22,37 @@ export const DiscountContent = () => {
 	const [selectedJourney, setSelectedJourney] = useState<VendoJourney | null>(
 		null
 	);
+
+	useEffect(() => {
+		if (journeysQuery.isSuccess && journeysQuery.data.length > 0) {
+			const journey = journeysQuery.data[0];
+			const firstLeg = journey.legs.at(0);
+			const lastLeg = journey.legs.at(-1);
+
+			if (firstLeg?.origin?.name && lastLeg?.destination?.name) {
+				addToHistory({
+					vbid: params.vbid,
+					origin: firstLeg.origin.name,
+					destination: lastLeg.destination.name,
+					departureDate: firstLeg.departure.toISOString(),
+					price: journey.price?.amount ?? null,
+					travelClass: params.travelClass,
+					passengerAge: params.passengerAge,
+					bahnCard: params.bahnCard,
+					hasDeutschlandTicket: params.hasDeutschlandTicket,
+				});
+			}
+		}
+	}, [
+		journeysQuery.isSuccess,
+		journeysQuery.data,
+		params.vbid,
+		params.travelClass,
+		params.passengerAge,
+		params.bahnCard,
+		params.hasDeutschlandTicket,
+		addToHistory,
+	]);
 
 	if (journeysQuery.isError) {
 		return <ErrorDisplay error={journeysQuery.error.message} />;

--- a/app/discount/useUrlParams.ts
+++ b/app/discount/useUrlParams.ts
@@ -3,15 +3,29 @@ import { useSearchParams } from "next/navigation";
 export const useUrlParams = () => {
 	const searchParams = useSearchParams();
 
+	const vbid = searchParams.get("vbid");
+
+	if (!vbid) {
+		throw new Error("Missing required parameter: vbid");
+	}
+
+	const travelClassParam = searchParams.get("travelClass");
+	const travelClass = travelClassParam
+		? Number.parseInt(travelClassParam, 10)
+		: 2;
+
+	const passengerAgeParam = searchParams.get("passengerAge");
+	const passengerAge = passengerAgeParam
+		? Number.parseInt(passengerAgeParam, 10)
+		: undefined;
+
 	return {
 		bahnCard: searchParams.has("bahnCard")
 			? Number.parseInt(searchParams.get("bahnCard")!, 10)
 			: null,
-		vbid: searchParams.get("vbid")!,
-		travelClass: Number.parseInt(searchParams.get("travelClass")!, 10),
+		vbid,
+		travelClass,
 		hasDeutschlandTicket: searchParams.get("hasDeutschlandTicket") === "true",
-		passengerAge: searchParams.get("passengerAge")
-			? Number.parseInt(searchParams.get("passengerAge")!, 10)
-			: undefined,
+		passengerAge,
 	};
 };

--- a/app/discount/useUrlParams.ts
+++ b/app/discount/useUrlParams.ts
@@ -19,10 +19,11 @@ export const useUrlParams = () => {
 		? Number.parseInt(passengerAgeParam, 10)
 		: undefined;
 
+	const bahnCardParam = searchParams.get("bahnCard");
+	const bahnCard = bahnCardParam !== null ? Number.parseInt(bahnCardParam, 10) : null;
+
 	return {
-		bahnCard: searchParams.has("bahnCard")
-			? Number.parseInt(searchParams.get("bahnCard")!, 10)
-			: null,
+		bahnCard,
 		vbid,
 		travelClass,
 		hasDeutschlandTicket: searchParams.get("hasDeutschlandTicket") === "true",

--- a/components/SearchForm/SearchForm.tsx
+++ b/components/SearchForm/SearchForm.tsx
@@ -2,8 +2,10 @@
 
 import { useRouter } from "next/navigation";
 import { useState } from "react";
+import { SearchHistory } from "./SearchHistory";
 import { URLInput } from "./URLInput";
 import { useLocalStorage } from "./useLocalStorage";
+import { useSearchHistory } from "./useSearchHistory";
 
 export const SearchForm = () => {
 	const router = useRouter();
@@ -23,6 +25,8 @@ export const SearchForm = () => {
 	);
 
 	const [travelClass, setTravelClass] = useLocalStorage("travelClass", "2");
+
+	const { history, removeFromHistory, clearHistory } = useSearchHistory();
 
 	const handleUrlParsingAndNavigation = () => {
 		if (!url.trim()) {
@@ -114,6 +118,7 @@ export const SearchForm = () => {
 				</div>
 
 				<button
+					type="button"
 					onClick={handleUrlParsingAndNavigation}
 					disabled={!url.trim()}
 					className="w-full bg-primary text-white py-3 px-4 rounded-full hover:cursor-pointer hover:bg-primary/80 disabled:opacity-50 disabled:cursor-not-allowed transition-colors text-lg font-semibold"
@@ -127,6 +132,12 @@ export const SearchForm = () => {
 					<strong>Fehler:</strong> {urlParseError}
 				</div>
 			)}
+
+			<SearchHistory
+				history={history}
+				onRemove={removeFromHistory}
+				onClear={clearHistory}
+			/>
 		</section>
 	);
 };

--- a/components/SearchForm/SearchForm.tsx
+++ b/components/SearchForm/SearchForm.tsx
@@ -133,11 +133,7 @@ export const SearchForm = () => {
 				</div>
 			)}
 
-			<SearchHistory
-				history={history}
-				onRemove={removeFromHistory}
-				onClear={clearHistory}
-			/>
+			{history.length > 0 && <SearchHistory history={history} onRemove={removeFromHistory} onClear={clearHistory} />}
 		</section>
 	);
 };

--- a/components/SearchForm/SearchHistory.tsx
+++ b/components/SearchForm/SearchHistory.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { formatPriceDE } from "@/utils/priceUtils";
+import { useRouter } from "next/navigation";
+import { type SearchHistoryItem } from "./useSearchHistory";
+
+interface SearchHistoryProps {
+	history: SearchHistoryItem[];
+	onRemove: (vbid: string) => void;
+	onClear: () => void;
+}
+
+export const SearchHistory = ({
+	history,
+	onRemove,
+	onClear,
+}: SearchHistoryProps) => {
+	const router = useRouter();
+
+	if (history.length === 0) {
+		return null;
+	}
+
+	const handleClick = (item: SearchHistoryItem) => {
+		const params = new URLSearchParams({
+			vbid: item.vbid,
+		});
+
+		if (item.travelClass !== undefined) {
+			params.set("travelClass", item.travelClass.toString());
+		}
+		if (item.passengerAge !== undefined) {
+			params.set("passengerAge", item.passengerAge.toString());
+		}
+		if (item.bahnCard !== undefined && item.bahnCard !== null) {
+			params.set("bahnCard", item.bahnCard.toString());
+		}
+		if (item.hasDeutschlandTicket) {
+			params.set("hasDeutschlandTicket", "true");
+		}
+
+		router.push(`/discount?${params.toString()}`);
+	};
+
+	const formatDate = (dateString: string) => {
+		const date = new Date(dateString);
+		return date.toLocaleDateString("de-DE", {
+			day: "2-digit",
+			month: "2-digit",
+			year: "numeric",
+		});
+	};
+
+	const formatSavedDate = (timestamp: number) => {
+		const date = new Date(timestamp);
+		return date.toLocaleDateString("de-DE", {
+			day: "2-digit",
+			month: "2-digit",
+		});
+	};
+
+	return (
+		<div className="mt-12 animate-in fade-in slide-in-from-top-2 duration-300">
+			<div className="flex items-center justify-between mb-4">
+				<h2 className="text-lg font-semibold text-foreground">
+					Letzte Suchen
+				</h2>
+				<button
+					type="button"
+					onClick={onClear}
+					className="text-sm text-foreground/60 hover:text-red-500 transition-colors"
+				>
+					Alle löschen
+				</button>
+			</div>
+
+			<div className="grid gap-3">
+				{history.map((item, index) => (
+					<div
+						key={`${item.vbid}-${index}`}
+						role="button"
+						tabIndex={0}
+						className="group relative bg-background border border-foreground/20 rounded-lg p-4 hover:shadow-md hover:border-primary/50 transition-all duration-200 cursor-pointer"
+						onClick={() => handleClick(item)}
+						onKeyDown={(e) => {
+							if (e.key === "Enter" || e.key === " ") {
+								e.preventDefault();
+								handleClick(item);
+							}
+						}}
+					>
+						<div className="flex items-center justify-between">
+							<div className="flex-1 min-w-0">
+								<div className="flex items-center gap-2 text-foreground">
+									<span className="font-medium truncate">
+										{item.origin}
+									</span>
+									<svg
+										className="w-4 h-4 text-foreground/50 flex-shrink-0"
+										fill="none"
+										stroke="currentColor"
+										viewBox="0 0 24 24"
+										aria-hidden="true"
+									>
+										<path
+											strokeLinecap="round"
+											strokeLinejoin="round"
+											strokeWidth={2}
+											d="M17 8l4 4m0 0l-4 4m4-4H3"
+										/>
+									</svg>
+									<span className="font-medium truncate">
+										{item.destination}
+									</span>
+								</div>
+
+								<div className="flex items-center gap-3 mt-1 text-sm text-foreground/60">
+									<span>{formatDate(item.departureDate)}</span>
+									{item.price !== null && (
+										<span className="text-green-600 font-medium">
+											{formatPriceDE(item.price)}
+										</span>
+									)}
+									<span className="text-xs text-foreground/40">
+										Preis vom {formatSavedDate(item.savedAt)}
+									</span>
+								</div>
+							</div>
+
+							<button
+								type="button"
+								onClick={(e) => {
+									e.stopPropagation();
+									onRemove(item.vbid);
+								}}
+								className="ml-3 p-2 rounded-full opacity-0 group-hover:opacity-100 hover:bg-red-100 hover:text-red-600 transition-all"
+								aria-label="Suchergebnis löschen"
+							>
+								<svg
+									className="w-4 h-4"
+									fill="none"
+									stroke="currentColor"
+									viewBox="0 0 24 24"
+									aria-hidden="true"
+								>
+									<path
+										strokeLinecap="round"
+										strokeLinejoin="round"
+										strokeWidth={2}
+										d="M6 18L18 6M6 6l12 12"
+									/>
+								</svg>
+							</button>
+						</div>
+					</div>
+				))}
+			</div>
+		</div>
+	);
+};

--- a/components/SearchForm/SearchHistory.tsx
+++ b/components/SearchForm/SearchHistory.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { formatPriceDE } from "@/utils/priceUtils";
-import { useRouter } from "next/navigation";
 import { type SearchHistoryItem } from "./useSearchHistory";
 
 interface SearchHistoryProps {
@@ -10,54 +9,37 @@ interface SearchHistoryProps {
 	onClear: () => void;
 }
 
+const buildUrl = (item: SearchHistoryItem) => {
+	const params = new URLSearchParams({ vbid: item.vbid });
+	if (item.travelClass !== undefined) params.set("travelClass", item.travelClass.toString());
+	if (item.passengerAge !== undefined) params.set("passengerAge", item.passengerAge.toString());
+	if (item.bahnCard !== null && item.bahnCard !== undefined) params.set("bahnCard", item.bahnCard.toString());
+	if (item.hasDeutschlandTicket) params.set("hasDeutschlandTicket", "true");
+	return `/discount?${params.toString()}`;
+};
+
+const formatDate = (dateString: string) => {
+	const date = new Date(dateString);
+	return date.toLocaleDateString("de-DE", {
+		day: "2-digit",
+		month: "2-digit",
+		year: "numeric",
+	});
+};
+
+const formatSavedDate = (timestamp: number) => {
+	const date = new Date(timestamp);
+	return date.toLocaleDateString("de-DE", {
+		day: "2-digit",
+		month: "2-digit",
+	});
+};
+
 export const SearchHistory = ({
 	history,
 	onRemove,
 	onClear,
 }: SearchHistoryProps) => {
-	const router = useRouter();
-
-	if (history.length === 0) {
-		return null;
-	}
-
-	const handleClick = (item: SearchHistoryItem) => {
-		const params = new URLSearchParams({
-			vbid: item.vbid,
-		});
-
-		if (item.travelClass !== undefined) {
-			params.set("travelClass", item.travelClass.toString());
-		}
-		if (item.passengerAge !== undefined) {
-			params.set("passengerAge", item.passengerAge.toString());
-		}
-		if (item.bahnCard !== undefined && item.bahnCard !== null) {
-			params.set("bahnCard", item.bahnCard.toString());
-		}
-		if (item.hasDeutschlandTicket) {
-			params.set("hasDeutschlandTicket", "true");
-		}
-
-		router.push(`/discount?${params.toString()}`);
-	};
-
-	const formatDate = (dateString: string) => {
-		const date = new Date(dateString);
-		return date.toLocaleDateString("de-DE", {
-			day: "2-digit",
-			month: "2-digit",
-			year: "numeric",
-		});
-	};
-
-	const formatSavedDate = (timestamp: number) => {
-		const date = new Date(timestamp);
-		return date.toLocaleDateString("de-DE", {
-			day: "2-digit",
-			month: "2-digit",
-		});
-	};
 
 	return (
 		<div className="mt-12 animate-in fade-in slide-in-from-top-2 duration-300">
@@ -76,18 +58,12 @@ export const SearchHistory = ({
 
 			<div className="grid gap-3">
 				{history.map((item, index) => (
-					<div
+					<a
 						key={`${item.vbid}-${index}`}
 						role="button"
 						tabIndex={0}
+						href={buildUrl(item)}
 						className="group relative bg-background border border-foreground/20 rounded-lg p-4 hover:shadow-md hover:border-primary/50 transition-all duration-200 cursor-pointer"
-						onClick={() => handleClick(item)}
-						onKeyDown={(e) => {
-							if (e.key === "Enter" || e.key === " ") {
-								e.preventDefault();
-								handleClick(item);
-							}
-						}}
 					>
 						<div className="flex items-center justify-between">
 							<div className="flex-1 min-w-0">
@@ -96,7 +72,7 @@ export const SearchHistory = ({
 										{item.origin}
 									</span>
 									<svg
-										className="w-4 h-4 text-foreground/50 flex-shrink-0"
+										className="w-4 h-4 text-foreground/50 shrink-0"
 										fill="none"
 										stroke="currentColor"
 										viewBox="0 0 24 24"
@@ -152,7 +128,7 @@ export const SearchHistory = ({
 								</svg>
 							</button>
 						</div>
-					</div>
+					</a>
 				))}
 			</div>
 		</div>

--- a/components/SearchForm/useSearchHistory.ts
+++ b/components/SearchForm/useSearchHistory.ts
@@ -20,15 +20,12 @@ export const useSearchHistory = () => {
 	const [history, setHistory] = useState<SearchHistoryItem[]>([]);
 
 	useEffect(() => {
-		if (typeof window === "undefined") return;
-
 		const stored = localStorage.getItem(STORAGE_KEY);
-		if (stored) {
-			try {
-				setHistory(JSON.parse(stored));
-			} catch {
-				setHistory([]);
-			}
+
+		try {
+			setHistory(stored ? JSON.parse(stored) : []);
+		} catch {
+			setHistory([]);
 		}
 	}, []);
 

--- a/components/SearchForm/useSearchHistory.ts
+++ b/components/SearchForm/useSearchHistory.ts
@@ -1,0 +1,68 @@
+import { useCallback, useEffect, useState } from "react";
+
+export interface SearchHistoryItem {
+	vbid: string;
+	origin: string;
+	destination: string;
+	departureDate: string;
+	price: number | null;
+	savedAt: number;
+	travelClass?: number;
+	passengerAge?: number;
+	bahnCard?: number | null;
+	hasDeutschlandTicket?: boolean;
+}
+
+const MAX_HISTORY_ITEMS = 5;
+const STORAGE_KEY = "searchHistory";
+
+export const useSearchHistory = () => {
+	const [history, setHistory] = useState<SearchHistoryItem[]>([]);
+
+	useEffect(() => {
+		if (typeof window === "undefined") return;
+
+		const stored = localStorage.getItem(STORAGE_KEY);
+		if (stored) {
+			try {
+				setHistory(JSON.parse(stored));
+			} catch {
+				setHistory([]);
+			}
+		}
+	}, []);
+
+	const addToHistory = useCallback((item: Omit<SearchHistoryItem, "savedAt">) => {
+		const newItem: SearchHistoryItem = {
+			...item,
+			savedAt: Date.now(),
+		};
+
+		setHistory((prev) => {
+			const filtered = prev.filter((h) => h.vbid !== item.vbid);
+			const updated = [newItem, ...filtered].slice(0, MAX_HISTORY_ITEMS);
+			localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+			return updated;
+		});
+	}, []);
+
+	const removeFromHistory = useCallback((vbid: string) => {
+		setHistory((prev) => {
+			const updated = prev.filter((h) => h.vbid !== vbid);
+			localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+			return updated;
+		});
+	}, []);
+
+	const clearHistory = useCallback(() => {
+		setHistory([]);
+		localStorage.removeItem(STORAGE_KEY);
+	}, []);
+
+	return {
+		history,
+		addToHistory,
+		removeFromHistory,
+		clearHistory,
+	};
+};

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
As mentioned in #201 this will add, that recent searches will be shown on the main page.
<img width="1618" height="493" alt="image" src="https://github.com/user-attachments/assets/b19a34e5-2955-44ec-966b-59522021489a" />

There's a limit of 5 recent searches that will be stored in localStorage, after which the oldest search gets deleted.
Clicking on the searches will redirect to /discount with the specific options such as "Deutschlandticket" that the user has set when first making that search.

This also fixes that url params travelClass and passengerAge will be automatically populated (assuming the default values), instead of throwing an error, if they aren't present.